### PR TITLE
Fix slot highlight alignment and detect custom enchants

### DIFF
--- a/src/client/java/cn/coatcn/bookhighlight/mixin/HandledScreenMixin.java
+++ b/src/client/java/cn/coatcn/bookhighlight/mixin/HandledScreenMixin.java
@@ -40,8 +40,9 @@ public abstract class HandledScreenMixin {
         var targets = ConfigManager.getInstance().getTargetNamesCn();
         if (EnchantMatch.isTargetEnchantedBook(stack, targets)) {
             int color = ConfigManager.getInstance().getHighlightColor(); // ARGB
-            int left = this.x + slot.x;
-            int top  = this.y + slot.y;
+            // context 在 drawSlot 之前已平移到容器原点，这里无需再次加 x/y
+            int left = slot.x + 1;
+            int top  = slot.y + 1;
             context.fill(left, top, left + 16, top + 16, color);
         }
     }

--- a/src/main/java/cn/coatcn/bookhighlight/EnchantMatch.java
+++ b/src/main/java/cn/coatcn/bookhighlight/EnchantMatch.java
@@ -3,7 +3,11 @@ package cn.coatcn.bookhighlight;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.nbt.NbtList;
 import net.minecraft.text.Text;
+import net.minecraft.text.Text.Serialization;
 
 import java.util.Set;
 
@@ -26,20 +30,42 @@ public class EnchantMatch {
         if (stack == null || !stack.isOf(Items.ENCHANTED_BOOK)) return false;
         if (targetNamesCn == null || targetNamesCn.isEmpty()) return false;
 
-        // 读取书中所有“存储附魔”及等级
+        // 读取书中所有“存储附魔”及等级（仅限客户端已注册的附魔）
         var map = EnchantmentHelper.get(stack); // 1.20.4 下仍可用来读取物品的附魔映射
-        if (map == null || map.isEmpty()) return false;
+        if (map != null && !map.isEmpty()) {
+            for (var entry : map.entrySet()) {
+                // 通过附魔对象在当前客户端语言环境下得到“名称 + 等级”的本地化文本
+                Text nameWithLevel = entry.getKey().getName(entry.getValue());
+                String localized = nameWithLevel.getString(); // 例如 “锋利 V”
+                String baseName = stripLevel(localized);      // 例如 “锋利”
 
-        for (var entry : map.entrySet()) {
-            // 通过附魔对象在当前客户端语言环境下得到“名称 + 等级”的本地化文本
-            Text nameWithLevel = entry.getKey().getName(entry.getValue());
-            String localized = nameWithLevel.getString(); // 例如 “锋利 V”
-            String baseName = stripLevel(localized);      // 例如 “锋利”
-
-            if (targetNamesCn.contains(baseName)) {
-                return true;
+                if (targetNamesCn.contains(baseName)) {
+                    return true;
+                }
             }
         }
+
+        // 补充：兼容服务端自定义附魔（通过 Lore 字段展示的名称）
+        NbtCompound nbt = stack.getNbt();
+        if (nbt != null && nbt.contains("display", NbtElement.COMPOUND_TYPE)) {
+            NbtCompound display = nbt.getCompound("display");
+            if (display.contains("Lore", NbtElement.LIST_TYPE)) {
+                NbtList lore = display.getList("Lore", NbtElement.STRING_TYPE);
+                for (int i = 0; i < lore.size(); i++) {
+                    String json = lore.getString(i);
+                    try {
+                        Text line = Serialization.fromJson(json);
+                        if (line != null) {
+                            String base = stripLevel(line.getString());
+                            if (targetNamesCn.contains(base)) {
+                                return true;
+                            }
+                        }
+                    } catch (Exception ignored) {}
+                }
+            }
+        }
+
         return false;
     }
 
@@ -49,7 +75,7 @@ public class EnchantMatch {
      */
     private static String stripLevel(String s) {
         if (s == null) return "";
-        // 去除末尾的空格与罗马数字
-        return s.replaceAll("\\s+[IVXLCDM]+$", "").trim();
+        // 去除末尾的空格与罗马数字/阿拉伯数字
+        return s.replaceAll("\\s+[IVXLCDM0-9]+$", "").trim();
     }
 }


### PR DESCRIPTION
## Summary
- Correct highlight coordinates so overlays line up with slots
- Detect enchantments shown via Lore to support server-only mods
- Strip both Roman numerals and digits from enchantment names

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c43994a6a083318d6ba120c386211d